### PR TITLE
style(docs): add logo and dark theme styles 

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,8 @@ export default defineConfig({
       provider: 'local'
     },
 
+    logo: '/images/logo.svg',
+
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Documentation', link: '/introduction/' },

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -80,6 +80,12 @@
   --vp-c-danger-soft: var(--vp-c-red-soft);
 }
 
+.dark {
+  --vp-c-bg: #0f172a !important;
+  --vp-c-bg-alt: #020617 !important;
+  --vp-c-bg-soft: #1e293b !important;
+}
+
 /**
  * Component: Button
  * -------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request introduces a new logo to the documentation site and adds custom styles for the dark theme to improve the visual appearance. Below are the key changes:

### Documentation Site Updates:
* Added a new logo (`/images/logo.svg`) to the site configuration in `docs/.vitepress/config.mts`.

### Dark Theme Styling:
* Introduced custom CSS variables for background colors in dark mode (`--vp-c-bg`, `--vp-c-bg-alt`, and `--vp-c-bg-soft`) within the `.dark` class in `docs/.vitepress/theme/style.css`.