### PR TITLE
chore(docs): add .gitignore for docs folder

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,7 @@
+/.vitepress/cache
+/.vitepress/dist
+/node_modules
+/bun.lockb
+/package-lock.json
+/pnpm-lock.yaml
+/pnpm-workspace.yaml


### PR DESCRIPTION
Include common ignore patterns for vitepress, node, and package managers.