### PR TITLE
refactor: use enum for service categories

### DIFF
--- a/app/Commands/DockerCompose/DockerComposeUsageExampleCommand.php
+++ b/app/Commands/DockerCompose/DockerComposeUsageExampleCommand.php
@@ -212,7 +212,6 @@ final class DockerComposeUsageExampleCommand extends Command
         $dockerCompose = new DockerCompose();
         $parsed        = $dockerCompose->parse($filePath);
 
-        // Example: Add a new service
         $newService = new Service(
             name: 'monitoring',
             image: 'prom/prometheus:latest',

--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -49,9 +49,9 @@ final class InitCommand extends Command
         $this->getCurrentDirectory();
 
         $this->serviceRegistry = new ServiceRegistry();
-        $this->services = new Collection();
-        $this->volumes  = new Collection();
-        $this->networks = new Collection();
+        $this->services        = new Collection();
+        $this->volumes         = new Collection();
+        $this->networks        = new Collection();
 
         if ($this->dockerComposeFileExists()) {
             info('🐳 Docker Compose file already exists.');

--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -48,10 +48,7 @@ final class InitCommand extends Command
     {
         $this->getCurrentDirectory();
 
-        // Initialize ServiceRegistry
         $this->serviceRegistry = new ServiceRegistry();
-
-        // Initialize collections
         $this->services = new Collection();
         $this->volumes  = new Collection();
         $this->networks = new Collection();
@@ -84,7 +81,6 @@ final class InitCommand extends Command
 
         $this->askForProjectInfo();
         $this->networks = $this->createBaseNetworks();
-        $this->askForApplicationService();
         $this->askForServices();
 
         $this->createDockerComposeFile();
@@ -110,7 +106,6 @@ final class InitCommand extends Command
             $this->volumes  = $existingCompose->volumes;
             $this->networks = $existingCompose->networks;
 
-            // Initialize ServiceRegistry
             $this->serviceRegistry = new ServiceRegistry();
 
             $this->askForServices();
@@ -141,7 +136,6 @@ final class InitCommand extends Command
             }
         );
 
-        // Store project name for later use
         $this->projectName = $projectName;
     }
 
@@ -155,21 +149,10 @@ final class InitCommand extends Command
         ]);
     }
 
-    private function askForApplicationService(): void
-    {
-        // TODO: Add Laravel Service implementation
-
-        note('💡 Laravel service implementation coming soon...');
-    }
-
-    /**
-     * Ask user to select and configure services using the service registry
-     */
     private function askForServices(): void
     {
         note('🛠️ Laravel Infrastructure Services');
 
-        // Get available service categories from ServiceRegistry
         $categories = $this->serviceRegistry->getCategories();
 
         $selectedCategories = multiselect(
@@ -244,7 +227,6 @@ final class InitCommand extends Command
 
         info("➕ Adding {$serviceTemplate->getDescription()}...");
 
-        // Prepare service
         $service = $serviceTemplate->createService();
 
         $service->networks = [$this->projectName];

--- a/app/Contracts/ServiceTemplateInterface.php
+++ b/app/Contracts/ServiceTemplateInterface.php
@@ -6,22 +6,14 @@ namespace Filaship\Contracts;
 
 use Filaship\DockerCompose\Service;
 use Filaship\DockerCompose\Volume;
+use Filaship\Enums\ServiceCategories;
 
 interface ServiceTemplateInterface
 {
-    /**
-     * Get the service name
-     */
     public function getName(): string;
 
-    /**
-     * Get the service description
-     */
     public function getDescription(): string;
 
-    /**
-     * Create the Docker Compose service
-     */
     public function createService(): Service;
 
     /**
@@ -31,28 +23,13 @@ interface ServiceTemplateInterface
      */
     public function getRequiredVolumes(): array;
 
-    /**
-     * Get default environment variables
-     */
     public function getDefaultEnvironment(): array;
 
-    /**
-     * Get default ports mapping
-     */
     public function getDefaultPorts(): array;
 
-    /**
-     * Get service category (database, cache, monitoring, etc.)
-     */
-    public function getCategory(): string;
+    public function getCategory(): ServiceCategories;
 
-    /**
-     * Check if this service requires external configuration files
-     */
     public function requiresExternalConfig(): bool;
 
-    /**
-     * Get list of external config files needed
-     */
     public function getRequiredConfigFiles(): array;
 }

--- a/app/DockerCompose/DockerCompose.php
+++ b/app/DockerCompose/DockerCompose.php
@@ -61,35 +61,30 @@ final class DockerCompose
         $configs  = new Collection();
         $secrets  = new Collection();
 
-        // Parse services
         if (isset($data['services']) && is_array($data['services'])) {
             foreach ($data['services'] as $name => $serviceData) {
                 $services->put($name, Service::fromArray($name, $serviceData));
             }
         }
 
-        // Parse networks
         if (isset($data['networks']) && is_array($data['networks'])) {
             foreach ($data['networks'] as $name => $networkData) {
                 $networks->put($name, Network::fromArray($name, $networkData ?? []));
             }
         }
 
-        // Parse volumes
         if (isset($data['volumes']) && is_array($data['volumes'])) {
             foreach ($data['volumes'] as $name => $volumeData) {
                 $volumes->put($name, Volume::fromArray($name, $volumeData ?? []));
             }
         }
 
-        // Parse configs
         if (isset($data['configs']) && is_array($data['configs'])) {
             foreach ($data['configs'] as $name => $configData) {
                 $configs->put($name, Config::fromArray($name, $configData ?? []));
             }
         }
 
-        // Parse secrets
         if (isset($data['secrets']) && is_array($data['secrets'])) {
             foreach ($data['secrets'] as $name => $secretData) {
                 $secrets->put($name, Secret::fromArray($name, $secretData ?? []));

--- a/app/Enums/ServiceCategories.php
+++ b/app/Enums/ServiceCategories.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Filaship\Enums;
+
+enum ServiceCategories: string
+{
+    case DATABASE   = 'database';
+    case CACHE      = 'cache';
+    case MONITORING = 'monitoring';
+    case MAIL       = 'mail';
+    case STORAGE    = 'storage';
+    case SEARCH     = 'search';
+    case TOOL       = 'tool';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DATABASE   => 'Database',
+            self::CACHE      => 'Cache',
+            self::MONITORING => 'Monitoring',
+            self::MAIL       => 'Mail',
+            self::STORAGE    => 'Storage',
+            self::SEARCH     => 'Search',
+            self::TOOL       => 'Tool',
+        };
+    }
+
+    public function allowMultiSelection(): bool
+    {
+        return match ($this) {
+            self::DATABASE => false,
+            default        => true,
+        };
+    }
+}

--- a/app/Services/Caches/MemcachedService.php
+++ b/app/Services/Caches/MemcachedService.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Caches;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class MemcachedService extends BaseService
@@ -19,9 +20,9 @@ class MemcachedService extends BaseService
         return 'Memcached High-Performance Memory Cache';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'cache';
+        return ServiceCategories::CACHE;
     }
 
     public function createService(): Service

--- a/app/Services/Caches/Redis7Service.php
+++ b/app/Services/Caches/Redis7Service.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Caches;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class Redis7Service extends BaseService
@@ -19,9 +20,9 @@ class Redis7Service extends BaseService
         return 'Redis 7 In-Memory Cache & Message Broker';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'cache';
+        return ServiceCategories::CACHE;
     }
 
     public function createService(): Service

--- a/app/Services/Databases/MariaDb11Service.php
+++ b/app/Services/Databases/MariaDb11Service.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Databases;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class MariaDb11Service extends BaseService
@@ -19,9 +20,9 @@ class MariaDb11Service extends BaseService
         return 'MariaDB 10.11 Database Server';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'database';
+        return ServiceCategories::DATABASE;
     }
 
     public function createService(): Service

--- a/app/Services/Databases/MongoDb7Service.php
+++ b/app/Services/Databases/MongoDb7Service.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Databases;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class MongoDb7Service extends BaseService
@@ -19,9 +20,9 @@ class MongoDb7Service extends BaseService
         return 'MongoDB 7 NoSQL Database';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'database';
+        return ServiceCategories::DATABASE;
     }
 
     public function createService(): Service

--- a/app/Services/Databases/Mysql8Service.php
+++ b/app/Services/Databases/Mysql8Service.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Databases;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class Mysql8Service extends BaseService
@@ -19,9 +20,9 @@ class Mysql8Service extends BaseService
         return 'MySQL 8.0 Database Server';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'database';
+        return ServiceCategories::DATABASE;
     }
 
     public function createService(): Service

--- a/app/Services/Databases/Postgres15Service.php
+++ b/app/Services/Databases/Postgres15Service.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Databases;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class Postgres15Service extends BaseService
@@ -19,9 +20,9 @@ class Postgres15Service extends BaseService
         return 'PostgreSQL 15 Database Server';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'database';
+        return ServiceCategories::DATABASE;
     }
 
     public function createService(): Service

--- a/app/Services/Mail/MailHogService.php
+++ b/app/Services/Mail/MailHogService.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Mail;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class MailHogService extends BaseService
@@ -19,9 +20,9 @@ class MailHogService extends BaseService
         return 'MailHog Email Testing Tool';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'mail';
+        return ServiceCategories::MAIL;
     }
 
     public function createService(): Service

--- a/app/Services/Monitoring/GrafanaService.php
+++ b/app/Services/Monitoring/GrafanaService.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Monitoring;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class GrafanaService extends BaseService
@@ -19,9 +20,9 @@ class GrafanaService extends BaseService
         return 'Grafana Analytics & Monitoring Dashboard';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'monitoring';
+        return ServiceCategories::MONITORING;
     }
 
     public function createService(): Service

--- a/app/Services/Search/ElasticsearchService.php
+++ b/app/Services/Search/ElasticsearchService.php
@@ -6,6 +6,7 @@ namespace Filaship\Services\Search;
 
 use Filaship\DockerCompose\Service;
 use Filaship\DockerCompose\Volume;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class ElasticsearchService extends BaseService
@@ -20,9 +21,9 @@ class ElasticsearchService extends BaseService
         return 'Elasticsearch 8.11 - Search and Analytics Engine';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'search';
+        return ServiceCategories::SEARCH;
     }
 
     public function createService(): Service

--- a/app/Services/ServiceRegistry.php
+++ b/app/Services/ServiceRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services;
 
 use Filaship\Contracts\ServiceTemplateInterface;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\Caches\MemcachedService;
 use Filaship\Services\Caches\Redis7Service;
 use Filaship\Services\Databases\MariaDb11Service;
@@ -33,15 +34,7 @@ class ServiceRegistry
 
     private function initializeCategories(): void
     {
-        $this->categories = [
-            'database'   => 'Databases',
-            'cache'      => 'Cache Systems',
-            'monitoring' => 'Monitoring',
-            'mail'       => 'Email Testing',
-            'storage'    => 'Storage Solutions',
-            'search'     => 'Search Engines',
-            'tool'       => 'Development Tools',
-        ];
+        $this->categories = ServiceCategories::cases();
     }
 
     private function registerServices(): void
@@ -65,8 +58,10 @@ class ServiceRegistry
         // Storage
         $this->register(new MinioService());
 
-        // Tools
+        // Mail
         $this->register(new MailHogService());
+
+        // Tools
         $this->register(new AdminerService());
     }
 
@@ -80,7 +75,7 @@ class ServiceRegistry
         return $this->services->get($name);
     }
 
-    public function getServicesByCategory(string $category): Collection
+    public function getServicesByCategory(ServiceCategories $category): Collection
     {
         return $this->services->filter(fn ($service) => $service->getCategory() === $category);
     }
@@ -102,36 +97,36 @@ class ServiceRegistry
 
     public function getDatabaseServices(): Collection
     {
-        return $this->getServicesByCategory('database');
+        return $this->getServicesByCategory(ServiceCategories::DATABASE);
     }
 
     public function getCacheServices(): Collection
     {
-        return $this->getServicesByCategory('cache');
+        return $this->getServicesByCategory(ServiceCategories::CACHE);
     }
 
     public function getMonitoringServices(): Collection
     {
-        return $this->getServicesByCategory('monitoring');
+        return $this->getServicesByCategory(ServiceCategories::MONITORING);
     }
 
     public function getToolServices(): Collection
     {
-        return $this->getServicesByCategory('tool');
+        return $this->getServicesByCategory(ServiceCategories::TOOL);
     }
 
     public function getMailServices(): Collection
     {
-        return $this->getServicesByCategory('mail');
+        return $this->getServicesByCategory(ServiceCategories::MAIL);
     }
 
     public function getStorageServices(): Collection
     {
-        return $this->getServicesByCategory('storage');
+        return $this->getServicesByCategory(ServiceCategories::STORAGE);
     }
 
     public function getSearchServices(): Collection
     {
-        return $this->getServicesByCategory('search');
+        return $this->getServicesByCategory(ServiceCategories::SEARCH);
     }
 }

--- a/app/Services/Storage/MinioService.php
+++ b/app/Services/Storage/MinioService.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Storage;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class MinioService extends BaseService
@@ -19,9 +20,9 @@ class MinioService extends BaseService
         return 'MinIO S3-Compatible Object Storage';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'storage';
+        return ServiceCategories::STORAGE;
     }
 
     public function createService(): Service

--- a/app/Services/Tools/AdminerService.php
+++ b/app/Services/Tools/AdminerService.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Filaship\Services\Tools;
 
 use Filaship\DockerCompose\Service;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\BaseService;
 
 class AdminerService extends BaseService
@@ -19,9 +20,9 @@ class AdminerService extends BaseService
         return 'Adminer Database Management Tool';
     }
 
-    public function getCategory(): string
+    public function getCategory(): ServiceCategories
     {
-        return 'tool';
+        return ServiceCategories::TOOL;
     }
 
     public function createService(): Service

--- a/tests/Unit/ServiceRegistryTest.php
+++ b/tests/Unit/ServiceRegistryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types = 1);
 
 use Filaship\Contracts\ServiceTemplateInterface;
+use Filaship\Enums\ServiceCategories;
 use Filaship\Services\ServiceRegistry;
 use Illuminate\Support\Collection;
 
@@ -14,21 +15,8 @@ test('initializes with predefined categories', function () {
     $categories = $this->registry->getCategories();
 
     expect($categories)->toBeArray()
-        ->and($categories)->toHaveKey('database')
-        ->and($categories)->toHaveKey('cache')
-        ->and($categories)->toHaveKey('monitoring')
-        ->and($categories)->toHaveKey('mail')
-        ->and($categories)->toHaveKey('storage')
-        ->and($categories)->toHaveKey('search')
-        ->and($categories)->toHaveKey('tool');
-});
-
-test('returns available categories', function () {
-    $categories = $this->registry->getAvailableCategories();
-
-    expect($categories)->toBeArray()
         ->and($categories)
-        ->toContain('database', 'cache', 'mail', 'tool');
+        ->toContain(ServiceCategories::DATABASE, ServiceCategories::CACHE, ServiceCategories::MONITORING, ServiceCategories::MAIL, ServiceCategories::STORAGE, ServiceCategories::SEARCH, ServiceCategories::TOOL);
 });
 
 test('can retrieve all services', function () {
@@ -39,14 +27,14 @@ test('can retrieve all services', function () {
 });
 
 test('can filter services by category', function () {
-    $databaseServices = $this->registry->getServicesByCategory('database');
+    $databaseServices = $this->registry->getServicesByCategory(ServiceCategories::DATABASE);
 
     expect($databaseServices)->toBeInstanceOf(Collection::class)
         ->and($databaseServices->count())->toBeGreaterThan(0);
 
     $databaseServices->each(function ($service) {
         expect($service)->toBeInstanceOf(ServiceTemplateInterface::class)
-            ->and($service->getCategory())->toBe('database');
+            ->and($service->getCategory())->toBe(ServiceCategories::DATABASE);
     });
 });
 
@@ -55,7 +43,7 @@ test('can retrieve specific service by name', function () {
 
     expect($mysql)->toBeInstanceOf(ServiceTemplateInterface::class)
         ->and($mysql->getName())->toBe('mysql')
-        ->and($mysql->getCategory())->toBe('database');
+        ->and($mysql->getCategory())->toBe(ServiceCategories::DATABASE);
 });
 
 test('returns null for non-existent service', function () {
@@ -68,47 +56,47 @@ test('has database services', function () {
     $databaseServices = $this->registry->getDatabaseServices();
 
     expect($databaseServices)->toBeInstanceOf(Collection::class)
-        ->and($databaseServices->count())->toBe(4); // MySQL, PostgreSQL, MongoDB, MariaDB
+        ->and($databaseServices->count())->toBe(4);
 });
 
 test('has cache services', function () {
     $cacheServices = $this->registry->getCacheServices();
 
     expect($cacheServices)->toBeInstanceOf(Collection::class)
-        ->and($cacheServices->count())->toBe(2); // Redis, Memcached
+        ->and($cacheServices->count())->toBe(2);
 });
 
 test('has mail services', function () {
     $mailServices = $this->registry->getMailServices();
 
     expect($mailServices)->toBeInstanceOf(Collection::class)
-        ->and($mailServices->count())->toBe(1); // MailHog
+        ->and($mailServices->count())->toBe(1);
 });
 
 test('has monitoring services', function () {
     $monitoringServices = $this->registry->getMonitoringServices();
 
     expect($monitoringServices)->toBeInstanceOf(Collection::class)
-        ->and($monitoringServices->count())->toBe(1); // Grafana
+        ->and($monitoringServices->count())->toBe(1);
 });
 
 test('has storage services', function () {
     $storageServices = $this->registry->getStorageServices();
 
     expect($storageServices)->toBeInstanceOf(Collection::class)
-        ->and($storageServices->count())->toBe(1); // MinIO
+        ->and($storageServices->count())->toBe(1);
 });
 
 test('has search services', function () {
     $searchServices = $this->registry->getSearchServices();
 
     expect($searchServices)->toBeInstanceOf(Collection::class)
-        ->and($searchServices->count())->toBe(1); // Elasticsearch
+        ->and($searchServices->count())->toBe(1);
 });
 
 test('has tool services', function () {
     $toolServices = $this->registry->getToolServices();
 
     expect($toolServices)->toBeInstanceOf(Collection::class)
-        ->and($toolServices->count())->toBe(1); // Adminer
+        ->and($toolServices->count())->toBe(1);
 });


### PR DESCRIPTION
This pull request introduces a significant refactor to the service category handling in the application by replacing string-based service categories with a new `ServiceCategories` enum. This change improves type safety, simplifies logic, and enhances maintainability. Additionally, redundant methods for managing service dependencies and environment variables have been removed, streamlining the codebase.

### Refactor to use `ServiceCategories` enum:
* Introduced a new `ServiceCategories` enum to replace string-based service categories, providing methods like `label()` for display names and `allowMultiSelection()` for selection rules. (`app/Enums/ServiceCategories.php`)
* Updated the `getCategory()` method in all service classes (e.g., `MemcachedService`, `Mysql8Service`, etc.) to return `ServiceCategories` instead of strings. (`[[1]](diffhunk://#diff-6f73d14d95fa266c64685019b1f7195ee1c1894bd03d553674adf743b3e7f772L22-R25)`, `[[2]](diffhunk://#diff-3493e3353649be467792f240739c9bf91e17635a9b22a407d13db65c827e436cL22-R25)`, and others)
* Modified `ServiceTemplateInterface` to reflect the change in the `getCategory()` method's return type. (`[app/Contracts/ServiceTemplateInterface.phpL34-L56](diffhunk://#diff-708cb8fd1e7838e8fc240a5cd295b955341b6bfe1fd6900fd91c8727dd210432L34-L56)`)
* Updated `ServiceRegistry` to initialize categories using `ServiceCategories::cases()` instead of a hardcoded array. (`[app/Services/ServiceRegistry.phpL36-R37](diffhunk://#diff-3bda47cc2e24cd9460283177de6323759d63810166b5ff1b6e7b7e2ddb75f0a3L36-R37)`)

### Code simplifications and improvements:
* Updated `askForCategoryServices` in `InitCommand` to accept a `ServiceCategories` enum instead of a string, simplifying category handling and removing redundant match statements. (`[[1]](diffhunk://#diff-4d72d061360c82276bb7c27e199be9e81fda111e9d4ba28ee63094d69a718603R182-R194)`, `[[2]](diffhunk://#diff-4d72d061360c82276bb7c27e199be9e81fda111e9d4ba28ee63094d69a718603L213-R220)`)
* Removed methods for generating environment variables based on service types, as this logic is no longer needed. (`[app/Commands/InitCommand.phpL285-L324](diffhunk://#diff-4d72d061360c82276bb7c27e199be9e81fda111e9d4ba28ee63094d69a718603L285-L324)`)
* Simplified the `addService` method by removing unnecessary comments and redundant logic. (`[app/Commands/InitCommand.phpL254-L276](diffhunk://#diff-4d72d061360c82276bb7c27e199be9e81fda111e9d4ba28ee63094d69a718603L254-L276)`)

### Other changes:
* Added `Str::lower` to normalize category inputs when converting them to `ServiceCategories`. (`[app/Commands/InitCommand.phpR182-R194](diffhunk://#diff-4d72d061360c82276bb7c27e199be9e81fda111e9d4ba28ee63094d69a718603R182-R194)`)
* Adjusted the `ServiceRegistry` to reorganize the registration of services for better clarity. (`[app/Services/ServiceRegistry.phpL68-R64](diffhunk://#diff-3bda47cc2e24cd9460283177de6323759d63810166b5ff1b6e7b7e2ddb75f0a3L68-R64)`)